### PR TITLE
strip newline so top-level value is correct

### DIFF
--- a/sal-postflight
+++ b/sal-postflight
@@ -206,7 +206,7 @@ def puppet_vers():
     if puppet_path:
         try:
             command = [puppet_path, '--version']
-            puppet_version = subprocess.check_output(command)
+            puppet_version = subprocess.check_output(command).strip()
         except subprocess.CalledProcessError as error:
             munkicommon.display_warning('Issue getting puppet version')
             munkicommon.display_warning(error.message)


### PR DESCRIPTION
As this becomes a top-level value about a machine, in order to make a widget out of the puppet version we need to strip the newline