### PR TITLE
decrease timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 USE_PKGBUILD=1
 include /usr/local/share/luggage/luggage.make
-PACKAGE_VERSION=1.0.7
+PACKAGE_VERSION=1.0.8
 TITLE=sal_scripts
 PACKAGE_NAME=sal_scripts
 REVERSE_DOMAIN=com.github.salopensource

--- a/utils.py
+++ b/utils.py
@@ -55,9 +55,9 @@ def pref(pref_name):
 
 def curl(url, data=None):
     if data:
-        cmd = ['/usr/bin/curl','--max-time','30','--connect-timeout', '10', '--data', data, url]
+        cmd = ['/usr/bin/curl','--max-time','8', '--connect-timeout', '2', '--data', data, url]
     else:
-        cmd = ['/usr/bin/curl','--max-time','30', '--connect-timeout', '10', url]
+        cmd = ['/usr/bin/curl','--max-time','4', '--connect-timeout', '2', url]
     task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = task.communicate()
     if task.returncode == 0:


### PR DESCRIPTION
satellite internet connections have latency around 600ms.  if you're triple that, bail and don't hold up munki run especially when sal server is timing out.

also, have lower timeouts when we aren't sending data.  the data sizes in here are all very small.