### PR TITLE
Puppet installed from ruby gem has alternative path, facter is not reported to Sal

### DIFF
--- a/postflight.d/sal-postflight
+++ b/postflight.d/sal-postflight
@@ -218,7 +218,8 @@ def puppet_vers():
     """Return puppet version as a string or None if not installed."""
     puppet_paths = (
         '/opt/puppetlabs/bin/puppet',
-        '/usr/bin/puppet')
+        '/usr/bin/puppet',
+        '/usr/local/bin/puppet')
     puppet_path = None
     for path in puppet_paths:
         if os.path.exists(path):
@@ -320,7 +321,7 @@ def get_facter_report():
     os.environ['FACTERLIB'] = desired_facter
 
     # if Facter is installed, perform a run
-    facter_paths = ('/opt/puppetlabs/bin/puppet', '/usr/bin/facter')
+    facter_paths = ('/opt/puppetlabs/bin/puppet', '/usr/bin/facter', '/usr/local/bin/facter')
     facter_path = None
     for path in facter_paths:
         if os.path.exists(path):


### PR DESCRIPTION
When Puppet is installed via `sudo gem install puppet`, the path specified for the puppet binary is `/usr/local/bin/puppet`. Similarly, Facter is also installed as part of the ruby gem installation, and is found at `/usr/local/bin/facter`.

This PR fixes an issue where Sal 3.x does not display Facter menus in the machine detail view due to Facter's path for ruby gem installs not being present in `sal-postflight`. 

Let me know if I got overzealous changing both paths or if they might need to be altered elsewhere.