### PR TITLE
Feature cert pref

### DIFF
--- a/postflight.d/sal-postflight
+++ b/postflight.d/sal-postflight
@@ -475,7 +475,7 @@ def send_hashed(ServerURL, hashed_data):
     if inventory:
         serverhash = None
         serverhash, stderr = utils.curl(hashurl)
-        if stderr is not None:
+        if stderr:
             return
         if serverhash != inventory_hash:
             hashed_data['base64bz2inventory'] = (
@@ -499,7 +499,7 @@ def send_install(ServerURL, install_data):
     if install_log_text:
         server_hash = None
         server_hash, stderr = utils.curl(hash_url)
-        if server_hash != install_log_hash and stderr is None:
+        if server_hash != install_log_hash and not stderr:
             install_data['base64bz2installlog'] = (
                 base64.b64encode(bz2.compress(install_log_text)))
             munkicommon.display_debug2("Install.log Response:")

--- a/utils.py
+++ b/utils.py
@@ -23,23 +23,28 @@ class HTTPError(Exception):
 
 
 def set_pref(pref_name, pref_value):
-    """Sets a preference, writing it to
-        /Library/Preferences/com.salopensource.sal.plist.
-        This should normally be used only for 'bookkeeping' values;
-        values that control the behavior of munki may be overridden
-        elsewhere (by MCX, for example)"""
+    """Sets a Sal preference.
+
+    The preference file on disk is located at
+    /Library/Preferences/com.salopensource.sal.plist.  This should
+    normally be used only for 'bookkeeping' values; values that control
+    the behavior of munki may be overridden elsewhere (by MCX, for
+    example)"""
     try:
         CFPreferencesSetValue(
-                              pref_name, pref_value, BUNDLE_ID,
-                              kCFPreferencesAnyUser, kCFPreferencesCurrentHost)
+            pref_name, pref_value, BUNDLE_ID, kCFPreferencesAnyUser,
+            kCFPreferencesCurrentHost)
         CFPreferencesAppSynchronize(BUNDLE_ID)
+
     except Exception:
         pass
 
 
 def pref(pref_name):
-    """Return a preference. Since this uses CFPreferencesCopyAppValue,
-    Preferences can be defined several places. Precedence is:
+    """Return a preference value.
+
+    Since this uses CFPreferencesCopyAppValue, Preferences can be defined
+    several places. Precedence is:
         - MCX
         - /var/root/Library/Preferences/com.salopensource.sal.plist
         - /Library/Preferences/com.salopensource.sal.plist
@@ -52,6 +57,7 @@ def pref(pref_name):
         'SyncScripts': True,
         'BasicAuth': True,
     }
+
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value == None:
         pref_value = default_prefs.get(pref_name)
@@ -59,36 +65,42 @@ def pref(pref_name):
         # /Library/Preferences/<BUNDLE_ID>.plist for admin
         # discoverability
         set_pref(pref_name, pref_value)
+
     if isinstance(pref_value, NSDate):
         # convert NSDate/CFDates to strings
         pref_value = str(pref_value)
+
     return pref_value
 
 
 def curl(url, data=None):
-    cmd = ['/usr/bin/curl']
-    basic_auth = pref('BasicAuth')
+    cmd = [
+        '/usr/bin/curl', '--silent', '--show-error', '--connect-timeout', '2']
 
+    basic_auth = pref('BasicAuth')
     if basic_auth:
         key = pref('key')
         user_pass = 'sal:%s' % key
-        cmd = cmd + ['--user', user_pass]
+        cmd += ['--user', user_pass]
+
+    max_time = '8' if data else '4'
+    cmd += ['--max-time', max_time]
 
     if data:
-        cmd = cmd + ['--max-time','8', '--connect-timeout', '2', '--data', data, url]
-    else:
-        cmd = cmd + ['--max-time','4', '--connect-timeout', '2', url]
+        cmd += ['--data', data]
 
-    task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd += [url]
+
+    import pdb; pdb.set_trace()
+    task = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = task.communicate()
-    if task.returncode == 0:
-        stderr = None
     return stdout, stderr
 
 
 def get_file_and_hash(path):
     """Given a filepath, return a tuple of (file contents, sha256."""
-    text = ""
+    text = ''
     if os.path.isfile(path):
         with open(path) as ifile:
             text = ifile.read()

--- a/utils.py
+++ b/utils.py
@@ -1,17 +1,26 @@
 #!/usr/bin/python
-import tempfile
-from Foundation import *
-import os
-import sys
-import subprocess
+
+
 import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+
+
+from Foundation import *
+
 
 BUNDLE_ID = 'com.github.salopensource.sal'
+
+
 class GurlError(Exception):
     pass
 
+
 class HTTPError(Exception):
     pass
+
 
 def set_pref(pref_name, pref_value):
     """Sets a preference, writing it to
@@ -26,6 +35,7 @@ def set_pref(pref_name, pref_value):
         CFPreferencesAppSynchronize(BUNDLE_ID)
     except Exception:
         pass
+
 
 def pref(pref_name):
     """Return a preference. Since this uses CFPreferencesCopyAppValue,
@@ -54,6 +64,7 @@ def pref(pref_name):
         pref_value = str(pref_value)
     return pref_value
 
+
 def curl(url, data=None):
     cmd = ['/usr/bin/curl']
     basic_auth = pref('BasicAuth')
@@ -74,6 +85,7 @@ def curl(url, data=None):
         stderr = None
     return stdout, stderr
 
+
 def get_file_and_hash(path):
     """Given a filepath, return a tuple of (file contents, sha256."""
     text = ""
@@ -82,6 +94,7 @@ def get_file_and_hash(path):
             text = ifile.read()
 
     return (text, hashlib.sha256(text).hexdigest())
+
 
 def dict_clean(items):
     result = {}


### PR DESCRIPTION
As was discussed in the Sal channel, changes to the Apple-provided curl in 10.13 means that it will fail verifying the Sal server's responses if the server is using a self-signed certificate.

In discussion with John Black, he mentioned that he has institutional constraints on his choice to get a "real" certificate, and time constraints on his ability to stand up his own CA to sign Sal's cert.

Using a curlrc file was surfaced as potential solution. However, doing so could cause confusion when distributing a curlrc file to the root user for this use, and potentially breaking _other_ things that use curl when it attempts to use only the `cacert` specified for Sal usage. The cert file referenced by `cacert` can contain multiple certificates, so this doesn't make it impossible to set up; it just means said admin would have to find all of the certificates needed and package them up into this file.

Alternately, the curlrc file could be provided a `capath` preference, although this has the same downsides.

This commit takes the approach of having the `utils.curl` look for an optional preference key of `CACert` to add to the curl subprocess call.

The last commit is the new feature...

There is some general PEP8 kind of cleanup.

Aside from the new preference / curl usage of it, the only real _change_ is that I made the `utils.curl` method use the `--silent` and `--show-errors` arguments to suppress the progress bar, but still output errors, and for the returned stderr value to be whatever subprocess passes. This means it will be an empty string for successful curls rather than getting converted to `None`. As some code in `sal-postflight` depended on `None` rather than a Falsey value, I updated that code as well, which is slightly more idiomatic as a result since it does things like `if stderr` rather than `if stderr == None`.

I agree that nobody should be using self-signed certificates. However, this does give the sal scripts a more explicit means for specifying a trusted cert than adding it to the system keychain.

I have not touched the Makefile to bump the version or anything. I'll leave that to the maintainer(s). I can see the possibility of adding some make stuff to build a sal-scripts package that includes the cert of your choice, coupled with a way in the code to use it by default if it's present without having to specify the preference. I'd be happy to implement that if it seems useful, but it seems like a stretch.