### PR TITLE
adding ability to add salt grains in place of facter facts or in addition to.

### DIFF
--- a/postflight.d/sal-postflight
+++ b/postflight.d/sal-postflight
@@ -376,7 +376,7 @@ def get_grain_report(insert_name):
     salt_path = '/opt/salt/bin/salt-call'
     # if salt doesn't exist we can just return an empty dict
     if not os.path.exists(salt_path):
-        display_debug2('Set to get Salt Grains but Salt isn\'t installed...')
+        munkicommon.display_debug2('Set to get Salt Grains but Salt isn\'t installed...')
         return dict()
     command = [salt_path, '--local', '--grains', '--out=json']
     try:

--- a/postflight.d/sal-postflight
+++ b/postflight.d/sal-postflight
@@ -61,8 +61,21 @@ def main():
         if os.path.exists(plugin_results_path):
             os.remove(plugin_results_path)
 
-    # report['Ohai'] = get_ohai_report()
+    insert_name = False
+
     report['Facter'] = get_facter_report()
+
+    if report['Facter']:
+        insert_name = True
+
+    if utils.pref('GetGrains'):
+        grains = get_grain_report(insert_name)
+        report['Facter'].update(grains)
+        insert_name = True  #set encase ohai is needed as well
+    # if utils.pref('GetOhai'):
+    #     ohais = get_ohai_report(insert_name)
+    #     report['Facter'].update(ohais)
+
     report['os_family'] = 'Darwin'
 
     ServerURL, NameType, bu_key = get_server_prefs()
@@ -356,6 +369,38 @@ def get_facter_report():
         os.environ['FACTERLIB'] = current_facterlib
 
     return hashrocket_flatten_dict(facter)
+
+
+def get_grain_report(insert_name):
+    '''Get the grain report from salt-call'''
+    salt_path = '/opt/salt/bin/salt-call'
+    # if salt doesn't exist we can just return an empty dict
+    if not os.path.exists(salt_path):
+        display_debug2('Set to get Salt Grains but Salt isn\'t installed...')
+        return dict()
+    command = [salt_path, '--local', '--grains', '--out=json']
+    try:
+        grains_report = subprocess.check_output(command)
+    except subprocess.CalledProcessError as error:
+        munkicommon.display_debug2('Issue getting grain report...')
+        munkicommon.display_debug2(error.message)
+    grains = dict()
+    new_grains = dict()
+    if grains_report:
+        try:
+            grains = json.loads(grains_report, object_pairs_hook=utils.dict_clean)
+        except:
+            pass
+    if 'local' in grains:
+        grains = grains['local']
+    for key, value in grains.items():
+        if 'productname' in key:
+            # productname value has a weird format that breaks sal if sent.
+            continue
+        if insert_name:
+            key = '{0}=>{1}'.format('grain',key)
+        new_grains[key] = value
+    return hashrocket_flatten_dict(new_grains)
 
 
 def hashrocket_flatten_dict(input_dict):

--- a/postflight.d/sal-postflight
+++ b/postflight.d/sal-postflight
@@ -71,7 +71,7 @@ def main():
     if utils.pref('GetGrains'):
         grains = get_grain_report(insert_name)
         report['Facter'].update(grains)
-        insert_name = True  #set encase ohai is needed as well
+        insert_name = True  #set in case ohai is needed as well
     # if utils.pref('GetOhai'):
     #     ohais = get_ohai_report(insert_name)
     #     report['Facter'].update(ohais)

--- a/utils.py
+++ b/utils.py
@@ -6,9 +6,12 @@ import os
 import subprocess
 import sys
 import tempfile
-
-
-from Foundation import *
+from Foundation import kCFPreferencesAnyUser, \
+                       kCFPreferencesCurrentHost, \
+                       CFPreferencesSetValue, \
+                       CFPreferencesAppSynchronize, \
+                       CFPreferencesCopyAppValue, \
+                       NSDate, NSArray
 
 
 BUNDLE_ID = 'com.github.salopensource.sal'
@@ -56,6 +59,8 @@ def pref(pref_name):
         'SkipFacts': [],
         'SyncScripts': True,
         'BasicAuth': True,
+        'GetGrains': False,
+        'GetOhai': False,
     }
 
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)


### PR DESCRIPTION
If you set the Preference `GetGrains` to `True` sal will now attempt to get Salt Grains and submit them with/as Facter Facts. If you have sal set to get both facts and grains it will insert `grain=>` in front of the grain key name. So the grain `cpu_model` would become `grain=>cpu_model`.