### PR TITLE
options for mutual TLS

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -96,6 +96,13 @@ def curl(url, data=None):
         key = pref('key')
         user_pass = 'sal:%s' % key
         cmd += ['--user', user_pass]
+        
+    ssl_client_cert = pref('SSLClientCertificate')
+    ssl_client_key = pref('SSLClientKey')
+    if ssl_client_cert:
+        cmd += ['--cert', ssl_client_cert]
+        if ssl_client_key:
+            cmd += ['--key', ssl_client_key]
 
     max_time = '8' if data else '4'
     cmd += ['--max-time', max_time]


### PR DESCRIPTION
New options `SSLClientCertificate` and `SSLClientKey` to allow curl to do mutual TLS connection to the server.
* the URL must be using TLS (https://*)
* you can use one of the following:
  * an alias for the name of a certificate/key pair in the system/user keychain (and provide a password for the key if needed)
  * a PKCS12 bundle and a password `/path/to/file.p12:password`
  * a key and certificate in PEM format.

See man page for curl, specifically, `--key`, `--cert`, `--key-type`, `--cert-type`.

This is, as of yet, untested...