### PR TITLE
ohai - respect organizations client.rb settings

### DIFF
--- a/postflight.d/sal-postflight
+++ b/postflight.d/sal-postflight
@@ -71,9 +71,13 @@ def main():
     if utils.pref('GetGrains'):
         grains = get_grain_report(insert_name)
         report['Facter'].update(grains)
-        insert_name = True  #set in case ohai is needed as well
+        insert_name = True  # set in case ohai is needed as well
     if utils.pref('GetOhai'):
-        ohais = get_ohai_report(insert_name)
+        if utils.pref('OhaiClientConfigPath'):
+            clientrbpath = utils.pref('OhaiClientConfigPath')
+        else:
+            clientrbpath = '/private/etc/chef/client.rb'
+        ohais = get_ohai_report(insert_name, clientrbpath)
         report['Facter'].update(ohais)
 
     report['os_family'] = 'Darwin'
@@ -283,13 +287,16 @@ def get_puppet_report():
     return puppetreport
 
 
-def get_ohai_report(insert_name):
+def get_ohai_report(insert_name, clientrbpath):
     report = None
     ohai_path = '/opt/chef/bin/ohai'
     ohai = dict()
     new_ohai = dict()
     if os.path.exists(ohai_path):
-        command = [ohai_path, '-c', '/private/etc/chef/client.rb']
+        if os.path.exists(clientrbpath):
+            command = [ohai_path, '-c', clientrbpath]
+        else:
+            command = [ohai_path]
         try:
             report = subprocess.check_output(command)
         except subprocess.CalledProcessError as error:
@@ -589,7 +596,7 @@ def send_catalogs(ServerURL, catalog_data):
         remote_data = FoundationPlist.readPlistFromString(response)
     except FoundationPlist.NSPropertyListSerializationException:
         remote_data = {}
-    if stderr:
+    if stderr is not None:
         for catalog in check_list:
             send = True
             for remote_item in remote_data:

--- a/postflight.d/sal-postflight
+++ b/postflight.d/sal-postflight
@@ -289,7 +289,7 @@ def get_ohai_report(insert_name):
     ohai = dict()
     new_ohai = dict()
     if os.path.exists(ohai_path):
-        command = [ohai_path]
+        command = [ohai_path, '-c', '/private/etc/chef/client.rb']
         try:
             report = subprocess.check_output(command)
         except subprocess.CalledProcessError as error:


### PR DESCRIPTION
This changes the behavior of Ohai to match the settings honored in a full-chef run.

Right now, ohai will collect the full set of plugins. If you are blocking (say passwords) this will come in.

This also fixes an issue I have found with 10.13.4b3, in where ohai is causing macOS to kernel panic. This fix, in conjunction to a client.rb fix will allow munki/sal to run without kernel panicking a 10.13.4b3 VM.

For people watching the fix in your client.rb file is this:
`ohai.disabled_plugins = [:CPU]`

A new key is available: `OhaiClientConfigPath`

If this is passed, it will use whatever path someone wants, otherwise it defaults to /private/etc/chef/client.rb. If this path doesn't exist, it will use the current ohai behavior.