### PR TITLE
Update preflight to send OS family to server during script download.

### DIFF
--- a/preflight.d/sal-preflight
+++ b/preflight.d/sal-preflight
@@ -1,24 +1,25 @@
 #!/usr/bin/python
-#
-#    preflight
-#        Retrieves queries to run in osquery
-#
+"""preflight
+
+Retrieves plugin scripts to run on client.
+"""
 
 
-import os
+import hashlib
 import json
 import optparse
-import hashlib
+import os
 import shutil
-
 import sys
-sys.path.append('/usr/local/munki')
-from munkilib import FoundationPlist
-from munkilib import munkicommon
-sys.path.append('/usr/local/sal')
+import urllib
+
+sys.path.extend(['/usr/local/munki', '/usr/local/sal'])
 import utils
+from munkilib import FoundationPlist, munkicommon
+
 
 EXTERNAL_SCRIPTS_DIR = '/usr/local/sal/external_scripts'
+
 
 def main():
     set_verbosity()
@@ -38,6 +39,7 @@ def main():
         cleanup_old_scripts(server_scripts)
         remove_empty_folders(EXTERNAL_SCRIPTS_DIR)
 
+
 def get_prefs():
     # Check for mandatory prefs and bail if any are missing.
     required_prefs = {}
@@ -49,16 +51,16 @@ def get_prefs():
             sys.exit('Required Sal preference "{}" is not set.'.format(key))
     return required_prefs
 
+
 def get_checksum():
-    """ Downloads the checkum of existing scripts.
+    """Downloads the checksum of existing scripts.
+
     Returns:
         A dict with the script name, plugin name and hash of the script
         or None if no external scripts are used.
     """
-
-
     preflight_url = "%s/preflight-v2/" % SERVER_URL
-    stdout, stderr = utils.curl(preflight_url)
+    stdout, stderr = utils.curl(preflight_url, data=urllib.urlencode({'os_family': 'Darwin'}))
 
     if stderr:
         munkicommon.display_debug2(stderr)
@@ -72,13 +74,13 @@ def get_checksum():
         munkicommon.display_debug2('Didn\'t receive valid JSON.')
         return None
 
+
 def download_scripts(server_scripts):
-    """ Checksums the local scripts and if it's missing or doesn't match,
-    downloads it.
-    """
+    """Checksum local scripts and if no matchs, download."""
     for server_script in server_scripts:
         download_required = False
-        target_script = os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'], server_script['filename'])
+        target_script = os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'],
+                                     server_script['filename'])
         if not os.path.exists(target_script):
             download_required = True
         else:
@@ -90,17 +92,18 @@ def download_scripts(server_scripts):
             munkicommon.display_debug2('downloading %s' % server_script['filename'])
             download_and_write_script(server_script)
 
+
 def download_and_write_script(server_script):
-    """
-    Downloads a named script from the server, writes it and makes it execuatble.
-    """
-    script_url = "%s/preflight-v2/get-script/%s/%s/" % (SERVER_URL, server_script['plugin'], server_script['filename'])
+    """Gets script from the server and makes it execuatble."""
+    script_url = "%s/preflight-v2/get-script/%s/%s/" % (SERVER_URL, server_script['plugin'],
+                                                        server_script['filename'])
     stdout, stderr = utils.curl(script_url)
     if stderr:
         munkicommon.display_debug2('Error received downloading script:')
         munkicommon.display_debug2(stderr)
 
-    script = open (os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'], server_script['filename']), 'w')
+    script = open (os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'],
+                                server_script['filename']), 'w')
     try:
         data = json.loads(stdout)
     except:
@@ -109,13 +112,16 @@ def download_and_write_script(server_script):
 
     script.write(data[0]['content'])
     script.close()
-    os.chmod(os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'], server_script['filename']), 0755)
+    os.chmod(
+        os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'], server_script['filename']),
+        0755)
+
 
 def create_dirs(server_scripts):
-    """ Creates any directories needed for external scripts
-    (named after the plugin)
-    """
+    """Creates any directories needed for external scripts
 
+    Directories are named after the plugin.
+    """
     for item in server_scripts:
         if not os.path.exists(os.path.join(
             EXTERNAL_SCRIPTS_DIR,
@@ -124,28 +130,26 @@ def create_dirs(server_scripts):
             ):
             os.makedirs(os.path.join(EXTERNAL_SCRIPTS_DIR,item['plugin']))
 
+
 def cleanup_old_scripts(server_scripts):
-    """
-    Finds and removes scripts on disk that aren't needed anymore.
-    """
+    """Finds and removes scripts on disk that aren't needed anymore."""
     if server_scripts == None:
         # No scripts from the server, nail the whole thing
         shutil.rmtree(EXTERNAL_SCRIPTS_DIR)
     else:
         keep = []
         for server_script in server_scripts:
-            keep.append(os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'], server_script['filename']))
+            keep.append(os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'],
+                                     server_script['filename']))
 
         for root, subFolders, files in os.walk(EXTERNAL_SCRIPTS_DIR):
             for script in files:
                 if os.path.join(root, script) not in keep:
                     os.remove(os.path.join(root, script))
 
-def remove_empty_folders(path):
-    """
-    Function to remove empty folders
-    """
 
+def remove_empty_folders(path):
+    """Function to remove empty folders."""
     for root, dirs, files in os.walk(path,topdown=False):
          for name in dirs:
              fname = os.path.join(root,name)
@@ -159,6 +163,7 @@ def set_verbosity():
     munkicommon.verbose = (
         5 if opts.debug else int(os.environ.get('MUNKI_VERBOSITY_LEVEL', 0)))
 
+
 def get_options():
     """Return commandline options."""
     usage = "%prog [options]"
@@ -169,6 +174,7 @@ def get_options():
     # We have no arguments, so don't store the results.
     opts, _ = option_parser.parse_args()
     return opts
+
 
 if __name__ == '__main__':
     all_prefs = get_prefs()

--- a/utils.py
+++ b/utils.py
@@ -79,8 +79,7 @@ def pref(pref_name):
 
 
 def curl(url, data=None):
-    cmd = [
-        '/usr/bin/curl', '--silent', '--show-error', '--connect-timeout', '2']
+    cmd = ['/usr/bin/curl', '--silent', '--show-error', '--connect-timeout', '2']
 
     # Use a PEM format certificate file to verify the peer. This is
     # useful primarily to support self-signed certificates, which are
@@ -96,7 +95,7 @@ def curl(url, data=None):
         key = pref('key')
         user_pass = 'sal:%s' % key
         cmd += ['--user', user_pass]
-        
+
     ssl_client_cert = pref('SSLClientCertificate')
     ssl_client_key = pref('SSLClientKey')
     if ssl_client_cert:


### PR DESCRIPTION
Primarily, this PR changes the `preflight-v2` request from `GET` to `POST` and includes the os family so that (pending merge) Sal can then only send (in this case) Darwin plugins to the client.

There's also some cleanup of the code to make it look more presentable.