### PR TITLE
Add try/except to sending catalog information

### DIFF
--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -649,7 +649,11 @@ def send_catalogs(ServerURL, catalog_data):
 
                 munkicommon.display_debug2(
                     "Submitting Catalog: {}".format(catalog['name']))
-                send_report(catalogsubmiturl, catalog_data)
+                try:
+                    send_report(catalogsubmiturl, catalog_data)
+                except OSError:
+                    munkicommon.display_debug2(
+                        "Error while submitting Catalog: {}".format(catalog['name']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If catalogs are to large, the argument list for subprocess will be to long.
This will result in OSError: [Errno 22] Invalid argument.

By adding try/except around the relevant code, we ensure that
at least the rest of the report is submitted.