### PR TITLE
Delete the touch file if it already exists

### DIFF
--- a/payload/usr/local/munki/postflight.d/sal-postflight
+++ b/payload/usr/local/munki/postflight.d/sal-postflight
@@ -11,7 +11,7 @@ SUBMIT_SCRIPT = '/usr/local/sal/bin/sal-submit'
 
 def write_touch_file():
     if os.path.exists(TOUCH_FILE_PATH):
-        os.unlink(TOUCH_FILE_PATH)
+        os.remove(TOUCH_FILE_PATH)
         
     if not os.path.exists(TOUCH_FILE_PATH):
         with open(TOUCH_FILE_PATH, 'a'):

--- a/payload/usr/local/munki/postflight.d/sal-postflight
+++ b/payload/usr/local/munki/postflight.d/sal-postflight
@@ -10,6 +10,9 @@ SUBMIT_SCRIPT = '/usr/local/sal/bin/sal-submit'
 
 
 def write_touch_file():
+    if os.path.exists(TOUCH_FILE_PATH):
+        os.unlink(TOUCH_FILE_PATH)
+        
     if not os.path.exists(TOUCH_FILE_PATH):
         with open(TOUCH_FILE_PATH, 'a'):
             os.utime(TOUCH_FILE_PATH, None)


### PR DESCRIPTION
I noticed that during a Munki bootstrap procedure, computers wouldn't check in with the Sal server right away after the bootstrap completed. 

If a Munki bootstrap procedure is kicked off, the touch file eventually gets created by `sal-postflight` at `/Users/Shared/.com.salopensource.sal.run`. But Munki starts another check/install cycle right away, so `sal-submit` sees that `managedsoftwareupdate` is running, bails after a few seconds, and doesn't clean up the `.com.salopensource.sal.run` touch file. When the subsequent Munki check/install cycles complete, the `.com.salopensource.sal.run` file doesn't get created and won't be picked up by the LaunchDaemon. 

The randomized `sal-submit` run would have eventually cleared the touch file on a successful run, but this PR has `sal-postflight` delete the touch file if it exists so that it can be picked up by the LaunchDaemon right away.