### PR TITLE
Prioritize internal directories in the Python search paths

### DIFF
--- a/payload/usr/local/munki/postflight
+++ b/payload/usr/local/munki/postflight
@@ -4,7 +4,7 @@
 
 import sys
 
-sys.path.append('/usr/local/sal')
+sys.path.insert(0, '/usr/local/sal')
 import utils
 
 

--- a/payload/usr/local/munki/preflight
+++ b/payload/usr/local/munki/preflight
@@ -4,7 +4,7 @@
 
 import sys
 
-sys.path.append('/usr/local/sal')
+sys.path.insert(0, '/usr/local/sal')
 import utils
 
 

--- a/payload/usr/local/munki/preflight.d/sal-preflight
+++ b/payload/usr/local/munki/preflight.d/sal-preflight
@@ -13,7 +13,7 @@ import shutil
 import sys
 import urllib
 
-sys.path.extend(['/usr/local/munki', '/usr/local/sal'])
+sys.path[:0] = ['/usr/local/munki', '/usr/local/sal']
 import utils
 from munkilib import FoundationPlist, munkicommon
 

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -25,9 +25,9 @@ from pprint import pformat
 # pylint: disable=E0611
 from SystemConfiguration import SCDynamicStoreCreate, SCDynamicStoreCopyValue
 
-sys.path.append('/usr/local/munki')
+sys.path.insert(0, '/usr/local/munki')
 from munkilib import FoundationPlist, munkicommon
-sys.path.append('/usr/local/sal')
+sys.path.insert(0, '/usr/local/sal')
 import macmodelshelf
 import utils
 import yaml

--- a/payload/usr/local/sal/utils.py
+++ b/payload/usr/local/sal/utils.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import time
 
-sys.path.append('/usr/local/munki')
+sys.path.insert(0, '/usr/local/munki')
 from munkilib import FoundationPlist
 from Foundation import kCFPreferencesAnyUser, \
     kCFPreferencesCurrentHost, \


### PR DESCRIPTION
Before this PR, internal directories were appended to the default
Python search paths. This could lead to import problems if the user has
installed modules which match filenames of internal modules (e.g.
`utils.py`) in the default Python search paths. In order to prevent
these problem, internal search paths are inserted in front of the
existing Python search paths.