### PR TITLE
Deal with offline checkins better

### DIFF
--- a/payload/usr/local/munki/postflight.d/sal-postflight
+++ b/payload/usr/local/munki/postflight.d/sal-postflight
@@ -52,6 +52,9 @@ def check_server_connection():
     return True
 
 def check_server_online():
+    # is the offline report pref true?
+    if not utils.pref('SendOfflineReport'):
+        return
     # read report
     report = utils.get_managed_install_report()
     # check for errors and warnings
@@ -59,7 +62,7 @@ def check_server_online():
         utils.set_pref('LastRunWasOffline', False)
         return
     # if they're there check is server is really offline
-    if not check_server_connection():
+    if check_server_connection():
         utils.set_pref('LastRunWasOffline', True)
         return
 

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -34,7 +34,7 @@ import yaml
 
 
 BUNDLE_ID = 'com.github.salopensource.sal'
-VERSION = '2.1.4'
+VERSION = '2.1.5'
 
 # To resolve unicode write errors set our default encoding to utf8
 reload(sys)

--- a/payload/usr/local/sal/utils.py
+++ b/payload/usr/local/sal/utils.py
@@ -66,6 +66,7 @@ def pref(pref_name):
         'GetGrains': False,
         'GetOhai': False,
         'LastRunWasOffline': False,
+        'SendOfflineReport': False,
     }
 
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
@@ -137,6 +138,7 @@ def pythonScriptRunning(scriptname):
         else:
             time.sleep(1)
             counter = counter + 1
+
 
 def check_script_running(scriptname):
     """


### PR DESCRIPTION
This:

* Adds a pref to send checkins whatever
* Fixes the logic - if the server is online now, but was offline when we had a 'bad' run, we assume the last run was offline and don't send it. If the server is offline now as well, that's a real problem.