### PR TITLE
Bugfix apple install times

### DIFF
--- a/payload/usr/local/sal/checkin_modules/apple_sus_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/apple_sus_checkin.py
@@ -156,8 +156,8 @@ def get_pending():
         rexp = re.compile(
             r'(?m)'  # Turn on multiline matching
             r'^\s+[*-] '  # Name lines start with 3 spaces and either a * or a -.
-            r'(?P<name>[^ ].*)[\r\n]'  # The rest of that line is the name.
-            r'.*\((?P<version>[^\)]+)'  # Capture the last parenthesized value on the next line.
+            r'(?P<name>.*)[\r\n]'  # The rest of that line is the name.
+            r'.*\((?P<version>[^ \)]*)'  # Capture the last parenthesized value on the next line.
             r'[^\r\n\[]*(?P<recommended>\[recommended\])?\s?'  # Capture [recommended] if there.
             r'(?P<action>\[(?:restart|shut down)\])?'  # Capture an action if present.
         )


### PR DESCRIPTION
If you're having time issues (#50), give this a try!

This updates the apple_sus_checkin checkin module to use `/Library/Receipts/InstallHistory.plist` instead of parsing the output of `softwareupdate --history`.

It also sneaks in another fix: Catalina's softwareupdate outputs in a different format, and this output is still used for pending update detection. So I reused work I had already done for the Salt mac_softwareupdate module here. This allowed me to add some additional data to the managed items for pending installs, namely whether they are "recommended" or not, and whether they require a restart or shut down.