### PR TITLE
Fix leftover debug code causing inventory submission every run.

### DIFF
--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -246,7 +246,7 @@ def send_inventory(server_url, serial):
         serverhash, stderr = utils.curl(hash_url)
         if stderr:
             return
-        if serverhash != inventory_hash or True:
+        if serverhash != inventory_hash:
             logging.info("Inventory is out of date; submitting...")
             inventory_submission = {
                 'serial': serial,


### PR DESCRIPTION
Client code was always submitting software inventory due to the "or True" that must have been put in at one point for troubleshooting and never removed.