### PR TITLE
Fix missing cpu_type key for VMs.

### DIFF
--- a/payload/usr/local/sal/checkin_modules/machine_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/machine_checkin.py
@@ -44,7 +44,7 @@ def process_system_profile():
     friendly_model = get_friendly_model(machine_results['serial'])
     if friendly_model:
         machine_results['machine_model_friendly'] = friendly_model
-    machine_results['cpu_type'] = system_profile['SPHardwareDataType'][0]['cpu_type']
+    machine_results['cpu_type'] = system_profile['SPHardwareDataType'][0].get('cpu_type', '')
     machine_results['cpu_speed'] = (
         system_profile['SPHardwareDataType'][0]['current_processor_speed'])
     machine_results['memory'] = system_profile['SPHardwareDataType'][0]['physical_memory']


### PR DESCRIPTION
Let me know if you think we should assign something other than an empty string; "VM", "Virtual", etc, or just not include that fact at all.