### PR TITLE
Remove trailing forward slash if present

### DIFF
--- a/report_broken_client/report_broken_client/main.swift
+++ b/report_broken_client/report_broken_client/main.swift
@@ -23,7 +23,10 @@ let defaults = UserDefaults.init(suiteName: "com.github.salopensource.sal")
 let key = defaults?.string(forKey: "key") ?? ""
 
 var urlString =  defaults?.string(forKey: "ServerURL") ?? ""
-
+if urlString.hasSuffix("/") {
+    let trailingSlash = urlString.lastIndex(of: "/")
+    urlString.remove(at: trailingSlash!)
+}
 urlString = urlString + "/report_broken_client/"
 
 let serial = getSerial()


### PR DESCRIPTION
We had our ServerURL set to `https://sal.server.com/` which broke the `report_broken_client` binary as it was attempting to send a POST to `https://sal.server.com//report_broken_client` resulting in a 404. This will strip a trailing forward slash if present.

I tested with both a server URL with _and_ without the trailing slash and the client checked in correctly.