### PR TITLE
Requests

### DIFF
--- a/payload/usr/local/munki/preflight.d/sal-preflight
+++ b/payload/usr/local/munki/preflight.d/sal-preflight
@@ -6,7 +6,6 @@ Retrieves plugin scripts to run on client.
 
 
 import argparse
-import json
 import os
 import pathlib
 import shutil
@@ -27,7 +26,7 @@ def main():
     if sal.pref('SyncScripts') == True:
         if not os.path.exists(EXTERNAL_SCRIPTS_DIR):
             os.makedirs(EXTERNAL_SCRIPTS_DIR)
-        server_scripts = get_checksum()
+        server_scripts = get_checksums()
         if server_scripts:
             create_dirs(server_scripts)
             download_scripts(server_scripts)
@@ -48,7 +47,7 @@ def get_prefs():
     return required_prefs
 
 
-def get_checksum():
+def get_checksums():
     """Downloads the checksum of existing scripts.
 
     Returns:
@@ -56,17 +55,24 @@ def get_checksum():
         or None if no external scripts are used.
     """
     preflight_url = f"{sal.pref('ServerURL')}/preflight-v2/"
-    stdout, stderr = sal.send_report(preflight_url, form_data={'os_family': 'Darwin'})
+    sal_client = sal.SalClient()
+    error_msg = None
+    try:
+        response = sal_client.post(preflight_url, data={'os_family': 'Darwin'})
+    except Exception as error:
+        error_msg = str(error)
+    if response.status_code != 200:
+        error_msg = f'Request failed with HTTP {response.status_code}'
 
-    if stderr:
-        munkicommon.display_debug2(stderr)
-    stdout_list = stdout.split("\n")
-    if "<h1>Page not found</h1>" not in stdout_list:
-        munkicommon.display_debug2(stdout)
+    if "<h1>Page not found</h1>" not in response.text:
+        munkicommon.display_debug2(response.text)
+
+    if error_msg:
+        munkicommon.display_debug2(error_msg)
 
     try:
-        return json.loads(stdout)
-    except:
+        return response.json()
+    except ValueError:
         munkicommon.display_debug2("Didn't receive valid JSON.")
         return None
 
@@ -94,16 +100,17 @@ def download_and_write_script(server_script):
     script_url = (
         f"{sal.pref('ServerURL')}/preflight-v2/get-script/"
         f"{server_script['plugin']}/{server_script['filename']}/")
-    stdout, stderr = sal.curl(script_url)
-    if stderr:
+    sal_client = sal.SalClient()
+    response = sal_client.get(script_url)
+    if response.status_code != 200:
         munkicommon.display_debug2('Error received downloading script:')
-        munkicommon.display_debug2(stderr)
+        munkicommon.display_debug2(response.text)
 
     script = open(
         os.path.join(EXTERNAL_SCRIPTS_DIR, server_script['plugin'], server_script['filename']),
         'w')
     try:
-        data = json.loads(stdout)
+        data = response.json()
     except:
         munkicommon.display_debug2('Did not receive valid JSON when requesting script content.')
         return False

--- a/payload/usr/local/munki/preflight.d/sal-preflight
+++ b/payload/usr/local/munki/preflight.d/sal-preflight
@@ -54,7 +54,7 @@ def get_checksums():
         A dict with the script name, plugin name and hash of the script
         or None if no external scripts are used.
     """
-    sal_client = sal.SalClient()
+    sal_client = sal.get_sal_client()
     error_msg = None
     try:
         response = sal_client.post('preflight-v2/', data={'os_family': 'Darwin'})
@@ -96,7 +96,7 @@ def download_scripts(server_scripts):
 
 def download_and_write_script(server_script):
     """Gets script from the server and makes it execuatble."""
-    sal_client = sal.SalClient()
+    sal_client = sal.get_sal_client()
     response = sal_client.get(
         f"preflight-v2/get-script/{server_script['plugin']}/{server_script['filename']}/")
     if response.status_code != 200:

--- a/payload/usr/local/munki/preflight.d/sal-preflight
+++ b/payload/usr/local/munki/preflight.d/sal-preflight
@@ -12,6 +12,7 @@ import shutil
 import sys
 import urllib
 
+import requests.exceptions
 import sal
 sys.path.append('/usr/local/munki')
 from munkilib import munkicommon
@@ -58,16 +59,15 @@ def get_checksums():
     error_msg = None
     try:
         response = sal_client.post('preflight-v2/', data={'os_family': 'Darwin'})
-    except Exception as error:
-        error_msg = str(error)
+    except requests.exceptions.RequestException as error:
+        munkicommon.display_debug2(str(error_msg))
+        return
     if response.status_code != 200:
-        error_msg = f'Request failed with HTTP {response.status_code}'
-
-    if "<h1>Page not found</h1>" not in response.text:
+        munkicommon.display_debug2(f'Request failed with HTTP {response.status_code}')
+        return
+    if response and "<h1>Page not found</h1>" not in response.text:
         munkicommon.display_debug2(response.text)
-
-    if error_msg:
-        munkicommon.display_debug2(error_msg)
+        return
 
     try:
         return response.json()
@@ -96,9 +96,14 @@ def download_scripts(server_scripts):
 
 def download_and_write_script(server_script):
     """Gets script from the server and makes it execuatble."""
-    sal_client = sal.get_sal_client()
-    response = sal_client.get(
-        f"preflight-v2/get-script/{server_script['plugin']}/{server_script['filename']}/")
+    try:
+        response = sal.get_sal_client().get(
+            f"preflight-v2/get-script/{server_script['plugin']}/{server_script['filename']}/")
+    except requests.exceptions.RequestException as error:
+        munkicommon.display_debug2('Error received downloading script:')
+        munkicommon.display_debug2(str(error))
+        return
+
     if response.status_code != 200:
         munkicommon.display_debug2('Error received downloading script:')
         munkicommon.display_debug2(response.text)
@@ -108,9 +113,9 @@ def download_and_write_script(server_script):
         'w')
     try:
         data = response.json()
-    except:
+    except ValueError:
         munkicommon.display_debug2('Did not receive valid JSON when requesting script content.')
-        return False
+        return
 
     script.write(data[0]['content'])
     script.close()

--- a/payload/usr/local/munki/preflight.d/sal-preflight
+++ b/payload/usr/local/munki/preflight.d/sal-preflight
@@ -54,11 +54,10 @@ def get_checksums():
         A dict with the script name, plugin name and hash of the script
         or None if no external scripts are used.
     """
-    preflight_url = f"{sal.pref('ServerURL')}/preflight-v2/"
     sal_client = sal.SalClient()
     error_msg = None
     try:
-        response = sal_client.post(preflight_url, data={'os_family': 'Darwin'})
+        response = sal_client.post('preflight-v2/', data={'os_family': 'Darwin'})
     except Exception as error:
         error_msg = str(error)
     if response.status_code != 200:
@@ -97,11 +96,9 @@ def download_scripts(server_scripts):
 
 def download_and_write_script(server_script):
     """Gets script from the server and makes it execuatble."""
-    script_url = (
-        f"{sal.pref('ServerURL')}/preflight-v2/get-script/"
-        f"{server_script['plugin']}/{server_script['filename']}/")
     sal_client = sal.SalClient()
-    response = sal_client.get(script_url)
+    response = sal_client.get(
+        f"preflight-v2/get-script/{server_script['plugin']}/{server_script['filename']}/")
     if response.status_code != 200:
         munkicommon.display_debug2('Error received downloading script:')
         munkicommon.display_debug2(response.text)

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -17,6 +17,7 @@ import subprocess
 import tempfile
 
 from Foundation import CFPreferencesCopyAppValue
+import requests.exceptions
 
 import sal
 
@@ -55,7 +56,7 @@ def main():
         logging.debug(json.dumps(submission, indent=4, default=sal.serializer))
     response = send_checkin(server_url)
 
-    if response.status_code == 200:
+    if response and response.status_code == 200:
         sal.clean_results()
 
     # Speed up manual runs by skipping these potentially slow-running,
@@ -212,8 +213,14 @@ def sanitize_submission():
 
 def send_checkin(server_url):
     logging.debug("Sending report")
-    sal_client = sal.get_sal_client()
-    return sal_client.post('checkin/', json=json.loads(pathlib.Path(sal.RESULTS_PATH).read_text()))
+    try:
+        response = sal.get_sal_client().post(
+            'checkin/', json=json.loads(pathlib.Path(sal.RESULTS_PATH).read_text()))
+    except requests.exceptions.RequestException as error:
+        logging.error('Failed to send report')
+        logging.debug(error)
+        response = None
+    return response
 
 
 def send_inventory(server_url, serial):
@@ -229,13 +236,22 @@ def send_inventory(server_url, serial):
         logging.debug(f"Inventory hash: {inventory_hash}")
         serverhash = None
         sal_client = sal.get_sal_client()
-        response = sal_client.get(f'inventory/hash/{serial}/')
+        try:
+            response = sal_client.get(f'inventory/hash/{serial}/')
+        except requests.exceptions.RequestException as error:
+            logging.error('Failed to get inventory hash')
+            logging.debug(error)
+            return
         if response.status_code == 200 and response.text != inventory_hash:
             logging.info("Inventory is out of date; submitting...")
             inventory_submission = {
                 'serial': serial,
                 'base64bz2inventory': sal.submission_encode(inventory)}
-            sal_client.post('inventory/submit/', data=inventory_submission)
+            try:
+                sal_client.post('inventory/submit/', data=inventory_submission)
+            except requests.exceptions.RequestException as error:
+                logging.error('Failed to submit inventory')
+                logging.debug(error)
 
 
 def send_catalogs(server_url, machine_group_key):
@@ -262,7 +278,9 @@ def send_catalogs(server_url, machine_group_key):
     sal_client = sal.get_sal_client()
     try:
         response = sal_client.post('catalog/hash/', data=hash_submission)
-    except:
+    except requests.exceptions.RequestException as error:
+        logging.error('Failed to get catalog hashes')
+        logging.debug(error)
         return
 
     try:
@@ -282,8 +300,9 @@ def send_catalogs(server_url, machine_group_key):
             logging.debug("Submitting Catalog: %s", catalog['name'])
             try:
                 sal_client.post(catalog_submit_url, data=catalog_submission)
-            except OSError:
-                logging.warning("Error while submitting Catalog: %s", catalog['name'])
+            except requests.exceptions.RequestException as error:
+                logging.error("Error while submitting Catalog: %s", catalog['name'])
+                logging.debug(error)
 
 
 def send_profiles(server_url, serial):
@@ -303,8 +322,11 @@ def send_profiles(server_url, serial):
     profile_out.unlink()
 
     profile_submission = {'serial': serial, 'base64bz2profiles': profiles}
-    sal_client = sal.get_sal_client()
-    sal_client.post('profiles/submit/', data=profile_submission)
+    try:
+        sal.get_sal_client().post('profiles/submit/', data=profile_submission)
+    except requests.exceptions.RequestException as error:
+        logging.error('Failed to submit profiles')
+        logging.debug(error)
 
 
 if __name__ == "__main__":

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -218,8 +218,6 @@ def send_checkin(server_url):
 
 def send_inventory(server_url, serial):
     logging.info('Processing inventory...')
-    inventory_submit_url = os.path.join(server_url, 'inventory/submit', '')
-
     managed_install_dir = (
         CFPreferencesCopyAppValue('ManagedInstallDir', 'ManagedInstalls') or
         '/Library/Managed Installs')
@@ -237,8 +235,7 @@ def send_inventory(server_url, serial):
             inventory_submission = {
                 'serial': serial,
                 'base64bz2inventory': sal.submission_encode(inventory)}
-            logging.debug("Inventory report response:")
-            sal_client.post(inventory_submit_url, data=inventory_submission)
+            sal_client.post('inventory/submit/', data=inventory_submission)
 
 
 def send_catalogs(server_url, machine_group_key):

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -237,7 +237,7 @@ def send_inventory(server_url, serial):
     inventory_plist = pathlib.Path(managed_install_dir) / 'ApplicationInventory.plist'
     logging.debug('ApplicationInventory.plist Path: %s', inventory_plist)
 
-    if inventory:= inventory_plist.read_bytes():
+    if inventory := inventory_plist.read_bytes():
         inventory_hash = sal.get_hash(inventory_plist)
         serverhash = None
         serverhash, stderr = sal.curl(hash_url)

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -211,16 +211,13 @@ def sanitize_submission():
 
 
 def send_checkin(server_url):
-    checkinurl = os.path.join(server_url, 'checkin', '')
-    logging.debug(f"Sending report to {checkinurl}")
-    logging.debug("Checkin Response:")
+    logging.debug("Sending report")
     sal_client = sal.SalClient()
-    return sal_client.post(checkinurl, json=json.loads(pathlib.Path(sal.RESULTS_PATH).read_text()))
+    return sal_client.post('checkin/', json=json.loads(pathlib.Path(sal.RESULTS_PATH).read_text()))
 
 
 def send_inventory(server_url, serial):
     logging.info('Processing inventory...')
-    hash_url = os.path.join(server_url, 'inventory/hash', serial, '')
     inventory_submit_url = os.path.join(server_url, 'inventory/submit', '')
 
     managed_install_dir = (
@@ -234,7 +231,7 @@ def send_inventory(server_url, serial):
         logging.debug(f"Inventory hash: {inventory_hash}")
         serverhash = None
         sal_client = sal.SalClient()
-        response = sal_client.get(hash_url)
+        response = sal_client.get(f'inventory/hash/{serial}/')
         if response.status_code == 200 and response.text != inventory_hash:
             logging.info("Inventory is out of date; submitting...")
             inventory_submission = {
@@ -246,7 +243,6 @@ def send_inventory(server_url, serial):
 
 def send_catalogs(server_url, machine_group_key):
     logging.info('Processing catalogs...')
-    hash_url = os.path.join(server_url, 'catalog/hash', '')
     catalog_submit_url = os.path.join(server_url, 'catalog/submit', '')
     managed_install_dir = (
         CFPreferencesCopyAppValue('ManagedInstallDir', 'ManagedInstalls') or
@@ -268,7 +264,7 @@ def send_catalogs(server_url, machine_group_key):
         'catalogs': sal.submission_encode(catalog_check_plist)}
     sal_client = sal.SalClient()
     try:
-        response = sal_client.post(hash_url, data=hash_submission)
+        response = sal_client.post('catalog/hash/', data=hash_submission)
     except:
         return
 
@@ -295,8 +291,6 @@ def send_catalogs(server_url, machine_group_key):
 
 def send_profiles(server_url, serial):
     logging.info('Processing profiles...')
-    profile_submit_url = os.path.join(server_url, 'profiles/submit', '')
-
     temp_dir = tempfile.mkdtemp()
     profile_out = pathlib.Path(temp_dir) / 'profiles.plist'
 
@@ -313,7 +307,7 @@ def send_profiles(server_url, serial):
 
     profile_submission = {'serial': serial, 'base64bz2profiles': profiles}
     sal_client = sal.SalClient()
-    sal_client.post(profile_submit_url, data=profile_submission)
+    sal_client.post('profiles/submit/', data=profile_submission)
 
 
 if __name__ == "__main__":

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -53,9 +53,9 @@ def main():
         submission = sal.get_checkin_results()
         logging.debug('Checkin submission:')
         logging.debug(json.dumps(submission, indent=4, default=sal.serializer))
-    _, errors = send_checkin(server_url)
+    response = send_checkin(server_url)
 
-    if not errors:
+    if response.status_code == 200:
         sal.clean_results()
 
     # Speed up manual runs by skipping these potentially slow-running,
@@ -214,16 +214,8 @@ def send_checkin(server_url):
     checkinurl = os.path.join(server_url, 'checkin', '')
     logging.debug(f"Sending report to {checkinurl}")
     logging.debug("Checkin Response:")
-    out, error = sal.send_report(checkinurl, json_path=sal.RESULTS_PATH)
-    log(out, error)
-    return out, error
-
-
-def log(out, error):
-    if out:
-        logging.debug(out.strip())
-    if error:
-        logging.debug(error.strip())
+    sal_client = sal.SalClient()
+    return sal_client.post(checkinurl, json=json.loads(pathlib.Path(sal.RESULTS_PATH).read_text()))
 
 
 def send_inventory(server_url, serial):
@@ -239,18 +231,17 @@ def send_inventory(server_url, serial):
 
     if inventory := inventory_plist.read_bytes():
         inventory_hash = sal.get_hash(inventory_plist)
+        logging.debug(f"Inventory hash: {inventory_hash}")
         serverhash = None
-        serverhash, stderr = sal.curl(hash_url)
-        if stderr:
-            return
-        if serverhash != inventory_hash:
+        sal_client = sal.SalClient()
+        response = sal_client.get(hash_url)
+        if response.status_code == 200 and response.text != inventory_hash:
             logging.info("Inventory is out of date; submitting...")
             inventory_submission = {
                 'serial': serial,
                 'base64bz2inventory': sal.submission_encode(inventory)}
             logging.debug("Inventory report response:")
-            out, error = sal.send_report(inventory_submit_url, form_data=inventory_submission)
-            log(out, error)
+            sal_client.post(inventory_submit_url, data=inventory_submission)
 
 
 def send_catalogs(server_url, machine_group_key):
@@ -275,29 +266,31 @@ def send_catalogs(server_url, machine_group_key):
     hash_submission = {
         'key': machine_group_key,
         'catalogs': sal.submission_encode(catalog_check_plist)}
-    response, stderr = sal.send_report(hash_url, form_data=hash_submission)
+    sal_client = sal.SalClient()
+    try:
+        response = sal_client.post(hash_url, data=hash_submission)
+    except:
+        return
 
-    if stderr is not None:
-        try:
-            remote_data = plistlib.loads(response.encode())
-        except plistlib.InvalidFileException:
-            remote_data = []
+    try:
+        remote_data = plistlib.loads(response.content)
+    except plistlib.InvalidFileException:
+        remote_data = []
 
-        for catalog in check_list:
-            if catalog not in remote_data:
-                contents = (pathlib.Path(catalog_dir) / catalog['name']).read_bytes()
-                catalog_submission = {
-                    'key': machine_group_key,
-                    'base64bz2catalog': sal.submission_encode(contents),
-                    'name': catalog['name'],
-                    'sha256hash': catalog['sha256hash']}
+    for catalog in check_list:
+        if catalog not in remote_data:
+            contents = (pathlib.Path(catalog_dir) / catalog['name']).read_bytes()
+            catalog_submission = {
+                'key': machine_group_key,
+                'base64bz2catalog': sal.submission_encode(contents),
+                'name': catalog['name'],
+                'sha256hash': catalog['sha256hash']}
 
-                logging.debug("Submitting Catalog: %s", catalog['name'])
-                try:
-                    out, error = sal.send_report(catalog_submit_url, form_data=catalog_submission)
-                    log(out, error)
-                except OSError:
-                    logging.warning("Error while submitting Catalog: %s", catalog['name'])
+            logging.debug("Submitting Catalog: %s", catalog['name'])
+            try:
+                sal_client.post(catalog_submit_url, data=catalog_submission)
+            except OSError:
+                logging.warning("Error while submitting Catalog: %s", catalog['name'])
 
 
 def send_profiles(server_url, serial):
@@ -319,10 +312,8 @@ def send_profiles(server_url, serial):
     profile_out.unlink()
 
     profile_submission = {'serial': serial, 'base64bz2profiles': profiles}
-
-    logging.debug("Profiles Response:")
-    out, error = sal.send_report(profile_submit_url, form_data=profile_submission)
-    log(out, error)
+    sal_client = sal.SalClient()
+    sal_client.post(profile_submit_url, data=profile_submission)
 
 
 if __name__ == "__main__":

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -212,7 +212,7 @@ def sanitize_submission():
 
 def send_checkin(server_url):
     logging.debug("Sending report")
-    sal_client = sal.SalClient()
+    sal_client = sal.get_sal_client()
     return sal_client.post('checkin/', json=json.loads(pathlib.Path(sal.RESULTS_PATH).read_text()))
 
 
@@ -228,7 +228,7 @@ def send_inventory(server_url, serial):
         inventory_hash = sal.get_hash(inventory_plist)
         logging.debug(f"Inventory hash: {inventory_hash}")
         serverhash = None
-        sal_client = sal.SalClient()
+        sal_client = sal.get_sal_client()
         response = sal_client.get(f'inventory/hash/{serial}/')
         if response.status_code == 200 and response.text != inventory_hash:
             logging.info("Inventory is out of date; submitting...")
@@ -259,7 +259,7 @@ def send_catalogs(server_url, machine_group_key):
     hash_submission = {
         'key': machine_group_key,
         'catalogs': sal.submission_encode(catalog_check_plist)}
-    sal_client = sal.SalClient()
+    sal_client = sal.get_sal_client()
     try:
         response = sal_client.post('catalog/hash/', data=hash_submission)
     except:
@@ -303,7 +303,7 @@ def send_profiles(server_url, serial):
     profile_out.unlink()
 
     profile_submission = {'serial': serial, 'base64bz2profiles': profiles}
-    sal_client = sal.SalClient()
+    sal_client = sal.get_sal_client()
     sal_client.post('profiles/submit/', data=profile_submission)
 
 

--- a/payload/usr/local/sal/checkin_modules/munki_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/munki_checkin.py
@@ -2,7 +2,6 @@
 
 
 import datetime
-import os
 import pathlib
 import plistlib
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sal_python_pkg/
 pyobjc==6.2
 requests==2.23.0
+MacSesh==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sal_python_pkg/
 pyobjc==6.2
+requests==2.23.0

--- a/sal_python_pkg/sal/__init__.py
+++ b/sal_python_pkg/sal/__init__.py
@@ -1,3 +1,3 @@
-from sal.client import SalClient
+from sal.client import SalClient, get_sal_client
 from sal.utils import *
 from sal.version import __version__

--- a/sal_python_pkg/sal/__init__.py
+++ b/sal_python_pkg/sal/__init__.py
@@ -1,2 +1,3 @@
+from sal.client import SalClient
 from sal.utils import *
 from sal.version import __version__

--- a/sal_python_pkg/sal/client.py
+++ b/sal_python_pkg/sal/client.py
@@ -5,6 +5,9 @@ import macsesh
 from sal.utils import pref
 
 
+_client_instance = None
+
+
 class SalClient():
 
     basic_timeout = (3.05, 4)
@@ -56,3 +59,10 @@ class SalClient():
         url = url[1:] if url.startswith('/') else url
         url = url[:-1] if url.endswith('/') else url
         return '/'.join((self.base_url, url)) + '/'
+
+
+def get_sal_client():
+    global _client_instance
+    if _client_instance is None:
+        _client_instance = SalClient()
+    return _client_instance

--- a/sal_python_pkg/sal/client.py
+++ b/sal_python_pkg/sal/client.py
@@ -1,0 +1,58 @@
+import logging
+
+import macsesh
+
+from sal.utils import pref
+
+
+class SalClient():
+
+    basic_timeout = (3.05, 4)
+    post_timeout = (3.05, 8)
+    base_url = ''
+
+    def __init__(self):
+        sesh = macsesh.KeychainSession()
+        # sesh = macsesh.SecureTransportSession()
+
+        base_url = pref('ServerURL')
+        self.base_url = base_url if not base_url.endswith('/') else base_url[:-1]
+
+        ca_cert = pref('CACert')
+        if ca_cert:
+            sesh.verify = ca_cert
+
+        basic_auth = pref('BasicAuth')
+        if basic_auth:
+            key = pref('key', '')
+            sesh.auth = ('sal', key)
+
+        # TODO: Handle keychain-based certs.
+        ssl_client_cert = pref('SSLClientCertificate')
+        ssl_client_key = pref('SSLClientKey')
+        if ssl_client_cert:
+            sesh.cert = (ssl_client_cert, ssl_client_key) if ssl_client_key else ssl_client_cert
+
+        self.sesh = sesh
+
+    def get(self, url):
+        url = self.build_url(url)
+        return self.log_response(self.sesh.get(url, timeout=self.basic_timeout))
+
+    def post(self, url, data=None, json=None):
+        url = self.build_url(url)
+        kwargs = {'timeout': self.post_timeout}
+        if json:
+            kwargs['json'] = json
+        else:
+            kwargs['data'] = data
+        return self.log_response(self.sesh.post(url, **kwargs))
+
+    def log_response(self, response):
+        logging.debug(f'Response HTTP {response.status_code}: {response.text}')
+        return response
+
+    def build_url(self, url):
+        url = url[1:] if url.startswith('/') else url
+        url = url[:-1] if url.endswith('/') else url
+        return '/'.join((self.base_url, url)) + '/'

--- a/sal_python_pkg/sal/exceptions.py
+++ b/sal_python_pkg/sal/exceptions.py
@@ -1,0 +1,2 @@
+class SalClientError(Exception):
+    pass

--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -142,48 +142,6 @@ def get_hash(file_path):
     return hashlib.sha256(text).hexdigest()
 
 
-class SalClient():
-
-    basic_timeout = (3.05, 4)
-    post_timeout = (3.05, 8)
-
-    def __init__(self):
-        sesh = macsesh.KeychainSession()
-
-        ca_cert = pref('CACert')
-        if ca_cert:
-            sesh.verify = ca_cert
-
-        basic_auth = pref('BasicAuth')
-        if basic_auth:
-            key = pref('key', '')
-            sesh.auth = ('sal', key)
-
-        # TODO: Handle keychain-based certs.
-        ssl_client_cert = pref('SSLClientCertificate')
-        ssl_client_key = pref('SSLClientKey')
-        if ssl_client_cert:
-            sesh.cert = (ssl_client_cert, ssl_client_key) if ssl_client_key else ssl_client_cert
-
-        self.sesh = sesh
-
-    def get(self, url):
-        return self.log_response(self.sesh.get(url, timeout=self.basic_timeout))
-
-
-    def post(self, url, data=None, json=None):
-        kwargs = {'timeout': self.post_timeout}
-        if json:
-            kwargs['json'] = json
-        else:
-            kwargs['data'] = data
-        return self.log_response(self.sesh.post(url, **kwargs))
-
-    def log_response(self, response):
-        logging.debug(f'Response HTTP {response.status_code}: {response.text}')
-        return response
-
-
 def add_plugin_results(plugin, data, historical=False):
     """Add data to the shared plugin results plist.
 

--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -209,7 +209,10 @@ def add_plugin_results(plugin, data, historical=False):
 def get_checkin_results():
     if os.path.exists(RESULTS_PATH):
         with open(RESULTS_PATH) as results_handle:
-            results = json.load(results_handle)
+            try:
+                results = json.load(results_handle)
+            except json.decoder.JSONDecodeError:
+                results = {}
     else:
         results = {}
 

--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -253,19 +253,22 @@ def serializer(obj):
 
 def run_scripts(dir_path, cli_args=None):
     results = []
-    for script in os.listdir(dir_path):
-        script_stat = os.stat(os.path.join(dir_path, script))
-        if not script_stat.st_mode & stat.S_IWOTH:
-            cmd = [os.path.join(dir_path, script)]
-            if cli_args:
-                cmd.append(cli_args)
-            try:
-                subprocess.call(cmd, stdin=None)
-                results.append(f"'{script}' ran successfully")
-            except (OSError, subprocess.CalledProcessError):
-                results.append(f"'{script}' had errors during execution!")
-        else:
+    skip_names = {'__pycache__'}
+    scripts = (p for p in pathlib.Path(dir_path).iterdir() if p.name not in skip_names)
+    for script in scripts:
+        if script.stat().st_mode & stat.S_IWOTH:
             results.append(f"'{script}' is not executable or has bad permissions")
+            continue
+
+        cmd = [script]
+        if cli_args:
+            cmd.append(cli_args)
+        try:
+            subprocess.call(cmd)
+            results.append(f"'{script}' ran successfully")
+        except (OSError, subprocess.CalledProcessError):
+            results.append(f"'{script}' had errors during execution!")
+
     return results
 
 


### PR DESCRIPTION
This PR pulls out the curl wrapper used currently and replaces it with python requests.

# Why?
This was predicated on having mysterious curl failures that I could only resolve by dropping from http2 down to http1.1 by editing the curl command used OR using a current brew curl instead of the OS-provided one.

Instead, I figured why not just use requests? So I created a separate project to provide requests tools to let you use the macOS keychain for verifying SSL certs (`pip install macsesh`) and moved all of the requests between the client and Sal into a client class.

This cleans up some of the error handling and logging as a freebie.

Outstanding, I have yet to hear from anyone regarding whether they use sal-scripts with client certs for mutual TLS that relies on specifying the cert by name (i.e. curl built with secure transport) rather than providing the path to a cert somewhere on disk. I don't have a test environment for this, and it seems unlikely that anyone else does, since the existing code seems to contradict the curl man page's information re: how to use certs by name and not actually work.

If you rely on this, and you want it to keep working, please contact me! I think we have an easy way to handle this, but I want to make sure!