### PR TITLE
Update shebangs to reference the python "Current" symlink.

### DIFF
--- a/payload/usr/local/munki/postflight
+++ b/payload/usr/local/munki/postflight
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 """Run all scripts found in the Munki postflight.d directory."""
 
 

--- a/payload/usr/local/munki/postflight.d/sal-postflight
+++ b/payload/usr/local/munki/postflight.d/sal-postflight
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import os

--- a/payload/usr/local/munki/preflight
+++ b/payload/usr/local/munki/preflight
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 """Run all scripts found in the Munki preflight.d directory."""
 
 

--- a/payload/usr/local/munki/preflight.d/sal-preflight
+++ b/payload/usr/local/munki/preflight.d/sal-preflight
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 """preflight
 
 Retrieves plugin scripts to run on client.

--- a/payload/usr/local/sal/bin/randomizer
+++ b/payload/usr/local/sal/bin/randomizer
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import argparse

--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 """sal-submit
 
 Coordinates running checkin modules and submitting their results to Sal.

--- a/payload/usr/local/sal/checkin_modules/apple_sus_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/apple_sus_checkin.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import datetime

--- a/payload/usr/local/sal/checkin_modules/machine_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/machine_checkin.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import pathlib
@@ -105,7 +105,7 @@ def get_model_code(serial):
             # Remove S prefix from scanned codes.
             serial = serial[1:]
         return serial[8:].upper()
-    
+
     elif 11 <= len(serial) <= 12:
         # 2010 Mac Pros starting with H or Y are 11 characters
         return serial[8:].upper()

--- a/payload/usr/local/sal/checkin_modules/munki_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/munki_checkin.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import datetime

--- a/payload/usr/local/sal/checkin_modules/profile_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/profile_checkin.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import pathlib

--- a/payload/usr/local/sal/checkin_modules/sal_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/sal_checkin.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import sal


### PR DESCRIPTION
This will avoid some work when python3.9 drops.