### PR TITLE
Fix for ValueError: Circular reference detected

### DIFF
--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -20,6 +20,7 @@ import requests.exceptions
 
 import sal
 
+from Foundation import NSDate
 
 CHECKIN_MODULES_DIR = "/usr/local/sal/checkin_modules"
 
@@ -77,6 +78,7 @@ def main():
     response = send_checkin(report)
 
     if response and response.status_code == 200:
+        sal.set_sal_pref("LastCheckDate", NSDate.new())
         sal.clean_results()
 
     # Speed up manual runs by skipping these potentially slow-running,
@@ -389,3 +391,4 @@ def _payload_cleanse(payload):
 
 if __name__ == "__main__":
     main()
+

--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -6,12 +6,13 @@ import bz2
 import datetime
 import hashlib
 import json
+import logging
 import os
 import platform
 import pathlib
 import plistlib
 
-
+logger = logging.getLogger(__name__)
 RESULTS_PATH = {"Darwin": "/usr/local/sal/checkin_results.json"}.get(platform.system())
 
 
@@ -97,8 +98,10 @@ def serializer(obj):
     elif isinstance(obj, bytes):
         return obj.decode("utf-8")
     else:
-        # if nothing else notify on what went wrong
-        raise TypeError(f"Unserializable object: {obj}. Type: {type(obj)}")
+        # instead of raising TypeError drop the obj, log it, and move on.
+        logger.debug(f"Cant serialize {obj}. Converting to an empty string.")
+        obj = ""
+        return obj
 
 
 

--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -6,13 +6,12 @@ import bz2
 import datetime
 import hashlib
 import json
-import logging
 import os
 import platform
 import pathlib
 import plistlib
 
-logger = logging.getLogger(__name__)
+
 RESULTS_PATH = {"Darwin": "/usr/local/sal/checkin_results.json"}.get(platform.system())
 
 
@@ -26,10 +25,8 @@ def get_hash(file_path):
 
 def add_plugin_results(plugin, data, historical=False):
     """Add data to the shared plugin results plist.
-
     This function creates the shared results plist file if it does not
     already exist; otherwise, it adds the entry by appending.
-
     Args:
         plugin (str): Name of the plugin returning data.
         data (dict): Dictionary of results.
@@ -74,9 +71,7 @@ def save_results(data):
 
 def set_checkin_results(module_name, data):
     """Set data by name to the shared results JSON file.
-
     Existing data is overwritten.
-
     Args:
         module_name (str): Name of the management source returning data.
         data (dict): Dictionary of results.
@@ -93,13 +88,8 @@ def serializer(obj):
     # for strings, so we don't have to handle them here.
     if isinstance(obj, datetime.datetime):
         # Make sure everything has been set to offset 0 / UTC time.
-        return obj.astimezone(datetime.timezone.utc).isoformat()
-    elif isinstance(obj, bytes):
-        return obj.decode("utf-8")
-    else:
-        # instead of raising TypeError drop the obj, log it, and move on.
-        logger.debug(f"Cant serialize {obj}. Converting to an empty string.")
-        return ""
+        obj = obj.astimezone(datetime.timezone.utc).isoformat()
+    return obj
 
 
 def submission_encode(data: bytes) -> bytes:

--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -93,7 +93,13 @@ def serializer(obj):
     if isinstance(obj, datetime.datetime):
         # Make sure everything has been set to offset 0 / UTC time.
         obj = obj.astimezone(datetime.timezone.utc).isoformat()
-    return obj
+        return obj
+    elif isinstance(obj, bytes):
+        return obj.decode("utf-8")
+    else:
+        # if nothing else notify on what went wrong
+        raise TypeError(f"Unserializable object: {obj}. Type: {type(obj)}")
+
 
 
 def submission_encode(data: bytes) -> bytes:

--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -93,16 +93,13 @@ def serializer(obj):
     # for strings, so we don't have to handle them here.
     if isinstance(obj, datetime.datetime):
         # Make sure everything has been set to offset 0 / UTC time.
-        obj = obj.astimezone(datetime.timezone.utc).isoformat()
-        return obj
+        return obj.astimezone(datetime.timezone.utc).isoformat()
     elif isinstance(obj, bytes):
         return obj.decode("utf-8")
     else:
         # instead of raising TypeError drop the obj, log it, and move on.
         logger.debug(f"Cant serialize {obj}. Converting to an empty string.")
-        obj = ""
-        return obj
-
+        return ""
 
 
 def submission_encode(data: bytes) -> bytes:


### PR DESCRIPTION
Maybe there is a better way to handle this before getting to `save_results` but from testing this works. 
I'm assuming the circular error is because the object passed to the serializer was returned back the same, not serialized, which was confusing to me since the circle is between the object and itself (I think).

Hopefully raising the TypeError for anything else that fails will prevent this from tripping things up. 