### PR TITLE
Don't try to JSON serialize binary data

### DIFF
--- a/sal_python_pkg/sal/utils.py
+++ b/sal_python_pkg/sal/utils.py
@@ -92,7 +92,9 @@ def serializer(obj):
     # for strings, so we don't have to handle them here.
     if isinstance(obj, datetime.datetime):
         # Make sure everything has been set to offset 0 / UTC time.
-        obj = obj.astimezone(datetime.timezone.utc).isoformat()
+        return obj.astimezone(datetime.timezone.utc).isoformat()
+    elif isinstance(obj, bytes):
+        return "BINARY DATA"
     return obj
 
 


### PR DESCRIPTION
Profiles (plist) allow binary data, but JSON does not. An example of this in the wild is using a profile to set the logo for NoMAD Login.

Interestingly, this issue is masked, at least in my case, with a `ValueError: Circular reference detected`. Only after digging into the code did I discover the issue was actually with trying to JSON encode binary data. Fixing this issue also fixed the Circular reference error (for me), so the issues with PR #90 may be solved with this instead.

This PR just replaces the binary data with the literal `"BINARY DATA"` using the existing serializer.