### PR TITLE
Use platform_UUID as fallback for catalina devices

### DIFF
--- a/payload/usr/local/sal/checkin_modules/machine_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/machine_checkin.py
@@ -56,6 +56,9 @@ def process_system_profile():
     )
 
     udid = system_profile["SPHardwareDataType"][0].get("provisioning_UDID")
+    if udid is None:
+        # plaform_UUID was the unique id until macOS 10.15
+        udid = system_profile["SPHardwareDataType"][0].get("platform_UUID")
     friendly_model = get_friendly_model(serial=machine_results["serial"], udid=udid)
     if friendly_model:
         machine_results["machine_model_friendly"] = friendly_model


### PR DESCRIPTION
We still have a number of Catalina devices in our org. Currently, the model cache is named `None.txt`, because `provisioning_UDID` was [introduced with Big Sur](https://developer.apple.com/documentation/xcode/distributing-your-app-to-registered-devices) it seems.

```
# cat /usr/local/sal/model_cache/None.txt 
MacBook Pro (Retina, Mid 2012)lip-osx-001284:checkin_modules root# sw_vers 
ProductName:	Mac OS X
ProductVersion:	10.15.7
BuildVersion:	19H1824
# cat /usr/local/sal/model_cache/None.txt 
MacBook Pro (Retina, Mid 2012)
```

This PR adds a trivial fallback to `platform_UUID` as a unique device identifier, which goes back to at least 10.12.