### PR TITLE
Remove the confusing `--verbose` vs. `--debug` CLI options and log more.

### DIFF
--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -30,17 +30,16 @@ def main():
     log_level = get_log_level(args)
     logging.basicConfig(level=log_level, format="%(asctime)s %(levelname)s %(message)s")
     logging.info("%s Version: %s", os.path.basename(__file__), sal.__version__)
-    if log_level == logging.DEBUG:
-        logging.debug("Sal client prefs:")
-        prefs = sal.prefs_report()
-        if args.url:
-            prefs["ServerURL"] = {"value": args.url, "forced": "commandline"}
-        if args.key:
-            prefs["key"] = {"value": args.key, "forced": "commandline"}
-        for k, v in prefs.items():
-            logging.debug(
-                f'\t{k}: {v["value"]} ({"profile" if v["forced"] else "prefs"})'
-            )
+    logging.info("Sal client prefs:")
+    prefs = sal.prefs_report()
+    if args.url:
+        prefs["ServerURL"] = {"value": args.url, "forced": "commandline"}
+    if args.key:
+        prefs["key"] = {"value": args.key, "forced": "commandline"}
+    for k, v in prefs.items():
+        logging.info(
+            f'\t{k}: {v["value"]} ({"profile" if v["forced"] else "prefs"})'
+        )
 
     exit_if_not_root()
     if sal.wait_for_script("sal-submit"):
@@ -51,7 +50,7 @@ def main():
     logging.info("Processing checkin modules...")
     script_results = sal.run_scripts(CHECKIN_MODULES_DIR)
     for message in script_results:
-        logging.debug(message)
+        logging.info(message)
 
     submission = sal.get_checkin_results()
     run_type = get_run_type(submission)
@@ -65,16 +64,15 @@ def main():
     sal.setup_sal_client()
     if args.url:
         sal.get_sal_client().base_url = args.url
-        logging.debug("Server URL overridden with %s", args.url)
+        logging.info("Server URL overridden with %s", args.url)
 
     if args.key:
         sesh = sal.get_sal_client().auth = ("sal", args.key)
         # Override the key in the report, since it's used for querying.
         report["Sal"]["extra_data"]["key"] = args.key
-        logging.debug("Machine group key overridden with %s", args.key)
-    if logging.getLogger().level <= 10:
-        logging.debug("Checkin submission:")
-        logging.debug(json.dumps(report, indent=4, default=sal.serializer))
+        logging.info("Machine group key overridden with %s", args.key)
+    logging.debug("Checkin submission:")
+    logging.debug(json.dumps(report, indent=4, default=sal.serializer))
     response = send_checkin(report)
 
     if response and response.status_code == 200:
@@ -95,11 +93,9 @@ def main():
 
 def get_log_level(args):
     """Set the verbosity based on options."""
-    loglevel = logging.CRITICAL
+    loglevel = logging.INFO
     if args.debug:
         loglevel = logging.DEBUG
-    elif args.verbose:
-        loglevel = logging.INFO
     return loglevel
 
 
@@ -118,7 +114,7 @@ def get_args():
         "--verbose",
         default=False,
         action="store_true",
-        help="Enable verbose output.",
+        help="Deprecated. Does nothing",
     )
     parser.add_argument(
         "-u", "--url", default=None, help="Override the server URL for testing."
@@ -167,7 +163,7 @@ def run_external_scripts(run_type):
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                         )
-                        logging.debug("%s ran successfully.", script)
+                        logging.info("%s ran successfully.", script)
                     except OSError:
                         logging.warning("Couldn't run %s", script)
                     except subprocess.CalledProcessError:
@@ -254,12 +250,12 @@ def sanitize_submission():
 
 
 def send_checkin(report):
-    logging.debug("Sending report")
+    logging.info("Sending report")
     try:
         response = sal.get_sal_client().post("checkin/", json=report)
     except requests.exceptions.RequestException as error:
         logging.error("Failed to send report")
-        logging.debug(error)
+        logging.error(error)
         response = None
     return response
 
@@ -270,18 +266,18 @@ def send_inventory(serial):
         "ManagedInstalls", "ManagedInstallDir", "/Library/Managed Installs"
     )
     inventory_plist = pathlib.Path(managed_install_dir) / "ApplicationInventory.plist"
-    logging.debug("ApplicationInventory.plist Path: %s", inventory_plist)
+    logging.info("ApplicationInventory.plist Path: %s", inventory_plist)
 
     if inventory := inventory_plist.read_bytes():
         inventory_hash = sal.get_hash(inventory_plist)
-        logging.debug(f"Inventory hash: {inventory_hash}")
+        logging.info(f"Inventory hash: {inventory_hash}")
         serverhash = None
         sal_client = sal.get_sal_client()
         try:
             response = sal_client.get(f"inventory/hash/{serial}/")
         except requests.exceptions.RequestException as error:
             logging.error("Failed to get inventory hash")
-            logging.debug(error)
+            logging.error(error)
             return
         if response.status_code == 200 and response.text != inventory_hash:
             logging.info("Inventory is out of date; submitting...")
@@ -293,7 +289,7 @@ def send_inventory(serial):
                 sal_client.post("inventory/submit/", data=inventory_submission)
             except requests.exceptions.RequestException as error:
                 logging.error("Failed to submit inventory")
-                logging.debug(error)
+                logging.error(error)
 
 
 def send_catalogs():
@@ -325,7 +321,7 @@ def send_catalogs():
         response = sal_client.post("catalog/hash/", data=hash_submission)
     except requests.exceptions.RequestException as error:
         logging.error("Failed to get catalog hashes")
-        logging.debug(error)
+        logging.error(error)
         return
 
     try:
@@ -343,12 +339,12 @@ def send_catalogs():
                 "sha256hash": catalog["sha256hash"],
             }
 
-            logging.debug("Submitting Catalog: %s", catalog["name"])
+            logging.info("Submitting Catalog: %s", catalog["name"])
             try:
                 sal_client.post("catalog/submit/", data=catalog_submission)
             except requests.exceptions.RequestException as error:
                 logging.error("Error while submitting Catalog: %s", catalog["name"])
-                logging.debug(error)
+                logging.error(error)
 
 
 def send_profiles(serial):
@@ -381,7 +377,7 @@ def send_profiles(serial):
         sal.get_sal_client().post("profiles/submit/", data=profile_submission)
     except requests.exceptions.RequestException as error:
         logging.error("Failed to submit profiles")
-        logging.debug(error)
+        logging.error(error)
 
 
 def _payload_cleanse(payload):


### PR DESCRIPTION
This sets the default loglevel to INFO (was CRITICAL) and reworks all of
the sal-submit logging to make more stuff INFO. It then removes the
`--verbose` arg.

This was originally meant to not spew a bunch of Sal stuff at the end of
Munki runs, but we've subsequently decoupled Sal submissions from Munki,
so that's not really a goal any longer.
