### PR TITLE
fix: sal-postflight

### DIFF
--- a/payload/usr/local/munki/postflight.d/sal-postflight
+++ b/payload/usr/local/munki/postflight.d/sal-postflight
@@ -31,11 +31,19 @@ def check_for_errors(report):
          "\t(-1009, 'The Internet connection appears to be offline.')"],
     ]
 
-    if munkicommon.pref('InstallAppleSoftwareUpdates'):
-        if warnings in target_warnings and errors == target_errors:
+    if munkicommon.pref("InstallAppleSoftwareUpdates"):
+        if warnings in target_warnings and any(
+            error.startswith(target_error)
+            for target_error in target_errors
+            for error in errors
+        ):
             return True
     else:
-        if errors == target_errors:
+        if any(
+            error.startswith(target_error)
+            for target_error in target_errors
+            for error in errors
+        ):
             return True
 
     return False


### PR DESCRIPTION
This should fix this check after munki changed the code for when it [throws this error](https://github.com/munki/munki/blob/3cc0cbb3201f08534cc260260476feaf444579d5/code/client/munkilib/updatecheck/core.py#L85).

The error no longer matches and gives the same issue that https://github.com/salopensource/sal-scripts/pull/45/files originally fixed.
