### PR TITLE
PayloadType missing

### DIFF
--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -382,9 +382,8 @@ def send_profiles(serial):
 
 def _payload_cleanse(payload):
     stored = ("PayloadIdentifier", "PayloadUUID", "PayloadType")
-    return {k: payload[k] for k in stored}
+    return {k: payload.get(k, "None") for k in stored}
 
 
 if __name__ == "__main__":
     main()
-

--- a/payload/usr/local/sal/checkin_modules/profile_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/profile_checkin.py
@@ -8,7 +8,6 @@ import tempfile
 
 import sal
 
-
 __version__ = "1.0.0"
 
 
@@ -29,7 +28,7 @@ def main():
         for count, payload in enumerate(payloads, start=1):
             data[f"payload {count}"] = payload
 
-        data["payload_types"] = ", ".join(p["PayloadType"] for p in payloads)
+        data["payload_types"] = ", ".join(p.get("PayloadType", "None") for p in payloads)
         data["profile_description"] = profile.get("ProfileDescription", "None")
         data["identifier"] = profile["ProfileIdentifier"]
         data["organization"] = profile.get("ProfileOrganization" or "None")


### PR DESCRIPTION
Noticed a profile we have, Kandji Agent Settings, was breaking check-in with a missing PayloadType.