### PR TITLE
Change timestamp to ISO 8601

### DIFF
--- a/payload/usr/local/sal/bin/sal-submit
+++ b/payload/usr/local/sal/bin/sal-submit
@@ -28,7 +28,7 @@ CHECKIN_MODULES_DIR = "/usr/local/sal/checkin_modules"
 def main():
     args = get_args()
     log_level = get_log_level(args)
-    logging.basicConfig(level=log_level, format="%(asctime)s %(levelname)s %(message)s")
+    logging.basicConfig(level=log_level, format="%(asctime)s %(levelname)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z")
     logging.info("%s Version: %s", os.path.basename(__file__), sal.__version__)
     logging.info("Sal client prefs:")
     prefs = sal.prefs_report()


### PR DESCRIPTION
`sal-submit` is currently logging timestamps as [asctime](https://docs.python.org/3/library/logging.html#logrecord-attributes), a human-readable format that does not provide any timezone information out-of-the-box:

```shell
2003-09-15 12:34:56,789
```

Proposing to change the default logging timestamp to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compatible one with the timezone offset:

```
2023‐09‐15T12:34:56+1000
```

**Caveats:**
- The `%z` [directive](https://docs.python.org/3/library/time.html#time.strftime) provides `+HHMM` / `-HHMM` style timezones offsets, omitting colons `:`, however this still qualifies as a valid ISO 8601 timestamp.
- There does not seem to be a valid [directive](https://docs.python.org/3/library/time.html#time.strftime) to display milliseconds - is this important?