### PR TITLE
Fix #74

### DIFF
--- a/payload/usr/local/sal/checkin_modules/apple_sus_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/apple_sus_checkin.py
@@ -67,11 +67,14 @@ def get_sus_facts():
         install_log = handle.readlines()
 
     for line in reversed(install_log):
-        # TODO: Stop if we go before the subprocess call datetime-wise
         if "Catalog: http" in line and "catalog" not in result:
             result["catalog"] = line.split()[-1]
         elif "SUScan: Elapsed scan time = " in line and "last_check" not in result:
-            result["last_check"] = _get_log_time(line).isoformat()
+            try:
+                result["last_check"] = _get_log_time(line).isoformat()
+            except AttributeError:
+                # _get_log_time returned None
+                pass
 
         if (log_time := _get_log_time(line)) and log_time < history_limit:
             # Let's not look earlier than when we started

--- a/payload/usr/local/sal/checkin_modules/profile_checkin.py
+++ b/payload/usr/local/sal/checkin_modules/profile_checkin.py
@@ -28,7 +28,9 @@ def main():
         for count, payload in enumerate(payloads, start=1):
             data[f"payload {count}"] = payload
 
-        data["payload_types"] = ", ".join(p.get("PayloadType", "None") for p in payloads)
+        data["payload_types"] = ", ".join(
+            p.get("PayloadType", "None") for p in payloads
+        )
         data["profile_description"] = profile.get("ProfileDescription", "None")
         data["identifier"] = profile["ProfileIdentifier"]
         data["organization"] = profile.get("ProfileOrganization" or "None")


### PR DESCRIPTION
This anticipates the possibility of getting a None from log processing and just continuing. This will stop throwing and blowing up the SUS script, but not likely to actually get any data. This is for an older version of macOS which we likely don't care about at this point, but it seems like a logical safeguard to put in place.
